### PR TITLE
Updated BasePage constructor to create driver

### DIFF
--- a/__tests__/pageObjects/BasePage.ts
+++ b/__tests__/pageObjects/BasePage.ts
@@ -1,12 +1,20 @@
-import { By, until, WebDriver, WebElement } from "selenium-webdriver";
+import { By, Builder, Capabilities, until, WebDriver, WebElement } from "selenium-webdriver";
 const chromedriver = require("chromedriver");
 
 export class BasePage {
     driver: WebDriver;
     url: string;
 
-    constructor(driver, url) {
-        this.driver = driver
+    constructor(url: string, driver?: WebDriver) {
+        
+        if(driver == undefined) {
+            this.driver = new Builder()
+            .withCapabilities(Capabilities.chrome())
+            .build();
+        }
+        else
+            this.driver = driver;
+            
         this.url = url
     }
 


### PR DESCRIPTION
BasePage constructor originally needed a driver to be passed to it each time a Page object was created. 
Updated BasePage constructor to create the driver instead (but have also kept the option to allow a driver to be passed to it if required)