### PR TITLE
Modified to exclude any files from pageObjects when npm test is exec…

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     preset: "ts-jest",
     testEnvironment: "node",
-    testTimeout: 30000
+    testTimeout: 30000,
+    testPathIgnorePatterns: ["__tests__/pageObjects/"]
   };


### PR DESCRIPTION
Needed to modify the config file to ignore any files in pageObjects. When executing the following to run all tests, it would also attempt to run all the pageObjects files and fail
> npm test